### PR TITLE
Changed default

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -304,7 +304,7 @@ class LoadStreams:
                 check_requirements(('pafy', 'youtube_dl==2020.12.2'))
                 import pafy
                 s = pafy.new(s).getbest(preftype="mp4").url  # YouTube URL
-            s = eval(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
+            s = eval(s) if s.isnumeric() else i  # i.e. s = '0' local webcam
             cap = cv2.VideoCapture(s)
             assert cap.isOpened(), f'{st}Failed to open {s}'
             w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))


### PR DESCRIPTION
In line 307, s is set to the integer version of the number in the string, if the string is not a number it should default to 0 (standard webcam for cv2.VideoCapture() ), however it is set to s which in this case would be a string, which would give an error in the next line. This is just stupid so changed it to i (which is always 0).

The fact that i even exists due to an enumerate for loop which only ever loops once is stupid but ill not make any drastic changes to the code, just ranting. 

# :)